### PR TITLE
Upstream connectivity + weighted depth/time mixing

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -76,6 +76,7 @@ app.get('/connectivity', async (req, res) => {
   const time_ranges = (req.query.time_range || "").split(",").filter(Boolean);
   const start_ids = (req.query.start_id || '').split(',').filter(Boolean);
   const depthWeights = parseDepthWeights(depths, req.query.depth_weight);
+  const timeWeights  = parseDepthWeights(time_ranges, req.query.time_weight);
 
   // Validate inputs
   if (!validateArray(depths, 10)) {
@@ -118,13 +119,11 @@ app.get('/connectivity', async (req, res) => {
     }
     const data = result.rows;
     
-    // Time-and-depth-weighted mean.
-    // Each row is weighted by its time-window duration (hours) × user-supplied depth weight.
-    const DT_H = { '00d-07d': 168, '07d-14d': 168, '14d-28d': 336 };
+    // Weighted mean: each row weighted by user-supplied depth weight × time weight.
     const weightedMean = rows => {
       let totalW = 0, totalWeighted = 0;
       for (const r of rows) {
-        const w = (DT_H[r.time_range] ?? 168) * (depthWeights[r.depth] ?? 1);
+        const w = (depthWeights[r.depth] ?? 1) * (timeWeights[r.time_range] ?? 1);
         totalW += w;
         totalWeighted += +r.weight * w;
       }
@@ -160,6 +159,7 @@ app.get('/connectivity-sources', async (req, res) => {
   const end_ids    = (req.query.end_id     || '').split(',').filter(Boolean);
   const habitable  = req.query.habitable === 'true';
   const depthWeights = parseDepthWeights(depths, req.query.depth_weight);
+  const timeWeights  = parseDepthWeights(time_ranges, req.query.time_weight);
 
   if (!validateArray(depths, 10)) {
     return res.status(400).json({ error: 'Invalid depth parameter. Must be array with max 10 items' });
@@ -203,12 +203,11 @@ app.get('/connectivity-sources', async (req, res) => {
 
     const data = result.rows;
 
-    // Time-and-depth-weighted mean per source
-    const DT_H = { '00d-07d': 168, '07d-14d': 168, '14d-28d': 336 };
+    // Weighted mean per source: depth weight × time weight
     const weightedMean = rows => {
       let totalW = 0, totalWeighted = 0;
       for (const r of rows) {
-        const w = (DT_H[r.time_range] ?? 168) * (depthWeights[r.depth] ?? 1);
+        const w = (depthWeights[r.depth] ?? 1) * (timeWeights[r.time_range] ?? 1);
         totalW += w;
         totalWeighted += +r.weight * w;
       }

--- a/api/server.js
+++ b/api/server.js
@@ -138,6 +138,96 @@ app.get('/connectivity', async (req, res) => {
   }
 });
 
+// upstream connectivity: for given target hex(es), return fractional contribution of each source
+// share(s→t) = F(s→t) / Σ_{s ∈ active} F(s→t)
+// When habitable=true, sum is restricted to habitable sources only (non-habitable excluded entirely)
+app.get('/connectivity-sources', async (req, res) => {
+
+  const depths     = (req.query.depth      || '').split(',').filter(Boolean);
+  const time_ranges = (req.query.time_range || '').split(',').filter(Boolean);
+  const end_ids    = (req.query.end_id     || '').split(',').filter(Boolean);
+  const habitable  = req.query.habitable === 'true';
+
+  if (!validateArray(depths, 10)) {
+    return res.status(400).json({ error: 'Invalid depth parameter. Must be array with max 10 items' });
+  }
+  if (!validateArray(time_ranges, 10)) {
+    return res.status(400).json({ error: 'Invalid time_range parameter. Must be array with max 10 items' });
+  }
+  if (!validateArray(end_ids, 10000, isValidId)) {
+    return res.status(400).json({ error: 'Invalid end_id parameter. Must be array of positive integers, max 10000 items' });
+  }
+
+  const end_ids_numbers = end_ids.map(x => Number(x));
+
+  try {
+    // Join with metadata when habitable filter is active so non-habitable sources
+    // are excluded from both the result and the denominator.
+    const queryText = habitable
+      ? `
+          SELECT c.start_id, c.depth, c.time_range, c.weight
+          FROM ${CONN_TABLE_NAME} c
+          JOIN ${META_TABLE_NAME} m ON c.start_id = m.id
+          WHERE c.end_id = ANY($1)
+            AND c.depth = ANY($2)
+            AND c.time_range = ANY($3)
+            AND m.habitable = 1;
+        `
+      : `
+          SELECT start_id, depth, time_range, weight
+          FROM ${CONN_TABLE_NAME}
+          WHERE end_id = ANY($1)
+            AND depth = ANY($2)
+            AND time_range = ANY($3);
+        `;
+
+    const result = await pool.query(queryText, [end_ids_numbers, depths, time_ranges]);
+    console.log('Request for /connectivity-sources:', { end_ids_numbers, depths, time_ranges, habitable });
+
+    if (result.rows.length === 0) {
+      return res.json([]);
+    }
+
+    const data = result.rows;
+
+    // Time-weighted mean per source, aggregated across all selected end_ids, depths, time_ranges
+    const DT_H = { '00d-07d': 168, '07d-14d': 168, '14d-28d': 336 };
+    const timeWeightedMean = rows => {
+      let totalHours = 0, totalWeighted = 0;
+      for (const r of rows) {
+        const h = DT_H[r.time_range] ?? 168;
+        totalHours += h;
+        totalWeighted += +r.weight * h;
+      }
+      return totalWeighted / (totalHours || 1);
+    };
+
+    const byStartId = data.reduce((acc, r) => {
+      (acc[r.start_id] ??= []).push(r);
+      return acc;
+    }, {});
+
+    const aggregates = Object.entries(byStartId).map(([start_id, rows]) => ({
+      start_id: Number(start_id),
+      weight: timeWeightedMean(rows),
+    }));
+
+    // Fractional shares: divide each source weight by the sum over all active sources
+    const total = aggregates.reduce((sum, a) => sum + a.weight, 0);
+    const shares = total > 0
+      ? aggregates.map(a => ({ ...a, raw_weight: a.weight / total }))
+      : aggregates.map(a => ({ ...a, raw_weight: 0 }));
+
+    // Log-normalise the fractional shares for visual encoding
+    const responsePayload = normalize(shares.map(a => ({ ...a, weight: a.raw_weight })));
+
+    res.json(responsePayload);
+  } catch (err) {
+    console.error('Error in /connectivity-sources:', err);
+    res.status(500).json({ error: 'Database query error' });
+  }
+});
+
 //metadata
 app.get('/metadata', async (req, res) => {
   try {

--- a/api/server.js
+++ b/api/server.js
@@ -54,6 +54,19 @@ function normalize(data) {
 }
 
 
+// Parse depth_weight param into a map { depth: normalised_weight }.
+// Falls back to equal weights if absent or mismatched length.
+function parseDepthWeights(depthArr, weightStr) {
+  const rawWeights = (weightStr || '').split(',').map(Number).filter(w => !isNaN(w));
+  if (rawWeights.length !== depthArr.length) {
+    // equal weights fallback
+    const eq = 1 / (depthArr.length || 1);
+    return Object.fromEntries(depthArr.map(d => [d, eq]));
+  }
+  const total = rawWeights.reduce((s, w) => s + w, 0) || 1;
+  return Object.fromEntries(depthArr.map((d, i) => [d, rawWeights[i] / total]));
+}
+
 // most used fetch
 // takes a list of depths, time ranges, ids
 // returns a table of connectivity data, averaged over all perumations of the input
@@ -62,6 +75,7 @@ app.get('/connectivity', async (req, res) => {
   const depths = (req.query.depth || "").split(",").filter(Boolean);
   const time_ranges = (req.query.time_range || "").split(",").filter(Boolean);
   const start_ids = (req.query.start_id || '').split(',').filter(Boolean);
+  const depthWeights = parseDepthWeights(depths, req.query.depth_weight);
 
   // Validate inputs
   if (!validateArray(depths, 10)) {
@@ -104,19 +118,17 @@ app.get('/connectivity', async (req, res) => {
     }
     const data = result.rows;
     
-    // Time-weighted mean: weight each row by the duration of its time window.
-    // Windows are non-overlapping (00d-07d, 07d-14d, 14d-28d), so this gives
-    // a physically meaningful average rate over the selected period.
-    // Depth rows are weighted equally (no natural physical weighting for depth).
+    // Time-and-depth-weighted mean.
+    // Each row is weighted by its time-window duration (hours) × user-supplied depth weight.
     const DT_H = { '00d-07d': 168, '07d-14d': 168, '14d-28d': 336 };
-    const timeWeightedMean = rows => {
-      let totalHours = 0, totalWeighted = 0;
+    const weightedMean = rows => {
+      let totalW = 0, totalWeighted = 0;
       for (const r of rows) {
-        const h = DT_H[r.time_range] ?? 168;
-        totalHours += h;
-        totalWeighted += +r.weight * h;
+        const w = (DT_H[r.time_range] ?? 168) * (depthWeights[r.depth] ?? 1);
+        totalW += w;
+        totalWeighted += +r.weight * w;
       }
-      return totalWeighted / (totalHours || 1);
+      return totalWeighted / (totalW || 1);
     };
 
     const byEndId = data.reduce((acc, r) => {
@@ -126,7 +138,7 @@ app.get('/connectivity', async (req, res) => {
 
     const aggregates = Object.entries(byEndId).map(([end_id, rows]) => ({
       end_id: typeof rows[0].end_id === 'number' ? Number(end_id) : String(end_id),
-      weight: timeWeightedMean(rows),
+      weight: weightedMean(rows),
     }));
         
     const responsePayload = normalize(aggregates);
@@ -147,6 +159,7 @@ app.get('/connectivity-sources', async (req, res) => {
   const time_ranges = (req.query.time_range || '').split(',').filter(Boolean);
   const end_ids    = (req.query.end_id     || '').split(',').filter(Boolean);
   const habitable  = req.query.habitable === 'true';
+  const depthWeights = parseDepthWeights(depths, req.query.depth_weight);
 
   if (!validateArray(depths, 10)) {
     return res.status(400).json({ error: 'Invalid depth parameter. Must be array with max 10 items' });
@@ -190,16 +203,16 @@ app.get('/connectivity-sources', async (req, res) => {
 
     const data = result.rows;
 
-    // Time-weighted mean per source, aggregated across all selected end_ids, depths, time_ranges
+    // Time-and-depth-weighted mean per source
     const DT_H = { '00d-07d': 168, '07d-14d': 168, '14d-28d': 336 };
-    const timeWeightedMean = rows => {
-      let totalHours = 0, totalWeighted = 0;
+    const weightedMean = rows => {
+      let totalW = 0, totalWeighted = 0;
       for (const r of rows) {
-        const h = DT_H[r.time_range] ?? 168;
-        totalHours += h;
-        totalWeighted += +r.weight * h;
+        const w = (DT_H[r.time_range] ?? 168) * (depthWeights[r.depth] ?? 1);
+        totalW += w;
+        totalWeighted += +r.weight * w;
       }
-      return totalWeighted / (totalHours || 1);
+      return totalWeighted / (totalW || 1);
     };
 
     const byStartId = data.reduce((acc, r) => {
@@ -209,7 +222,7 @@ app.get('/connectivity-sources', async (req, res) => {
 
     const aggregates = Object.entries(byStartId).map(([start_id, rows]) => ({
       start_id: Number(start_id),
-      weight: timeWeightedMean(rows),
+      weight: weightedMean(rows),
     }));
 
     // Fractional shares: divide each source weight by the sum over all active sources

--- a/database/init/init_db.py
+++ b/database/init/init_db.py
@@ -78,15 +78,20 @@ try:
         logger.info(f"  Loading {pq_file.name}...")
         load_connectivity(engine, data_path=pq_file)
 
-    logger.info("Building connectivity index and running ANALYZE...")
+    logger.info("Building connectivity indices and running ANALYZE...")
     with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
         conn.execute(text(f'''
             CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_connect_dtr_inc
             ON "{SCHEMA}"."{CONNECTIVITY_TABLE_NAME}" (depth, time_range, start_id)
             INCLUDE (end_id, weight);
         '''))
+        conn.execute(text(f'''
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_connect_dtr_inc_reverse
+            ON "{SCHEMA}"."{CONNECTIVITY_TABLE_NAME}" (depth, time_range, end_id)
+            INCLUDE (start_id, weight);
+        '''))
         conn.execute(text(f'ANALYZE "{SCHEMA}"."{CONNECTIVITY_TABLE_NAME}";'))
-    logger.info("Connectivity data loaded with index and ANALYZE")
+    logger.info("Connectivity data loaded with indices and ANALYZE")
 
     # Mark initialization as complete
     logger.info("Creating completion marker...")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import DeckGL from '@deck.gl/react';
 import { GeoJsonLayer } from '@deck.gl/layers';
 import StaticMap from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
-import ControlPanel from './ControlPanel';
+import ControlPanel, { type DepthWeights } from './ControlPanel';
 import InfoBox from './InfoBox';
 import { theme, type RGBA } from './theme';
 
@@ -58,7 +58,7 @@ interface FeatureCollection {
 }
 
 function App() {
-  const [selectedDepths, setSelectedDepths] = useState<string[]>(['05m']);
+  const [depthWeights, setDepthWeights] = useState<DepthWeights>({ '05m': 1, '10m': 1, '15m': 1 });
   const [selectedTimes, setSelectedTimes] = useState<string[]>(['07d-14d']);
   const [feature, setFeature] = useState<FeatureCollection | null>(null);
   const [metadata, setMetadata] = useState<Record<number, Metadata> | null>(null);
@@ -76,6 +76,12 @@ function App() {
   const [hoveredId, setHoveredId] = useState<number | null>(null);
   const [clickIds, setClickIds] = useState<number[]>([]);
   const [tooltip, setTooltip] = useState<{x: number; y: number; content: string} | null>(null);
+
+  // Derive depth params for API: only depths with weight > 0, with normalised weights
+  const activeDepths = Object.entries(depthWeights).filter(([, w]) => w > 0);
+  const depthTotal = activeDepths.reduce((s, [, w]) => s + w, 0);
+  const depthParam  = activeDepths.map(([d]) => d).join(',');
+  const weightParam = activeDepths.map(([, w]) => (w / depthTotal).toFixed(4)).join(',');
 
   //fetch geojson features for display
   useEffect(() => {
@@ -122,12 +128,12 @@ function App() {
 
   // Downstream fetch
   useEffect(() => {
-    if (direction !== 'downstream' || !clickIds?.length) {
+    if (direction !== 'downstream' || !clickIds?.length || !depthParam) {
       setConnections([]);
       return;
     }
     const ctrl = new AbortController();
-    const fetchURL = `api/connectivity?depth=${selectedDepths.join(',')}&time_range=${selectedTimes.join(',')}&start_id=${clickIds.join(',')}&op=mean`;
+    const fetchURL = `api/connectivity?depth=${depthParam}&depth_weight=${weightParam}&time_range=${selectedTimes.join(',')}&start_id=${clickIds.join(',')}`;
     console.log('Trying to fetch:', fetchURL);
     (async () => {
       try {
@@ -140,16 +146,16 @@ function App() {
       }
     })();
     return () => ctrl.abort();
-  }, [clickIds, selectedTimes, selectedDepths, direction]);
+  }, [clickIds, selectedTimes, depthParam, weightParam, direction]);
 
   // Upstream fetch
   useEffect(() => {
-    if (direction !== 'upstream' || !clickIds?.length) {
+    if (direction !== 'upstream' || !clickIds?.length || !depthParam) {
       setSourceConnections([]);
       return;
     }
     const ctrl = new AbortController();
-    const fetchURL = `api/connectivity-sources?depth=${selectedDepths.join(',')}&time_range=${selectedTimes.join(',')}&end_id=${clickIds.join(',')}&habitable=${isHabitableShown}`;
+    const fetchURL = `api/connectivity-sources?depth=${depthParam}&depth_weight=${weightParam}&time_range=${selectedTimes.join(',')}&end_id=${clickIds.join(',')}&habitable=${isHabitableShown}`;
     console.log('Trying to fetch:', fetchURL);
     (async () => {
       try {
@@ -162,7 +168,7 @@ function App() {
       }
     })();
     return () => ctrl.abort();
-  }, [clickIds, selectedTimes, selectedDepths, direction, isHabitableShown]);
+  }, [clickIds, selectedTimes, depthParam, weightParam, direction, isHabitableShown]);
 
   const clearHex = () => {
     setClickIds([]);
@@ -506,8 +512,8 @@ function App() {
         } as React.CSSProperties}
       >
         <ControlPanel
-          selectedDepths={selectedDepths}
-          onDepthChange={setSelectedDepths}
+          depthWeights={depthWeights}
+          onDepthWeightsChange={setDepthWeights}
           selectedTimes={selectedTimes}
           onTimeChange={setSelectedTimes}
           clearHex={clearHex}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import DeckGL from '@deck.gl/react';
 import { GeoJsonLayer } from '@deck.gl/layers';
 import StaticMap from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
-import ControlPanel, { type DepthWeights } from './ControlPanel';
+import ControlPanel, { type DepthWeights, type TimeWeights } from './ControlPanel';
 import InfoBox from './InfoBox';
 import { theme, type RGBA } from './theme';
 
@@ -59,7 +59,7 @@ interface FeatureCollection {
 
 function App() {
   const [depthWeights, setDepthWeights] = useState<DepthWeights>({ '05m': 1, '10m': 1, '15m': 1 });
-  const [selectedTimes, setSelectedTimes] = useState<string[]>(['07d-14d']);
+  const [timeWeights, setTimeWeights] = useState<TimeWeights>({ '00d-07d': 1, '07d-14d': 1, '14d-28d': 1 });
   const [feature, setFeature] = useState<FeatureCollection | null>(null);
   const [metadata, setMetadata] = useState<Record<number, Metadata> | null>(null);
 
@@ -77,11 +77,17 @@ function App() {
   const [clickIds, setClickIds] = useState<number[]>([]);
   const [tooltip, setTooltip] = useState<{x: number; y: number; content: string} | null>(null);
 
-  // Derive depth params for API: only depths with weight > 0, with normalised weights
+  // Derive depth params for API
   const activeDepths = Object.entries(depthWeights).filter(([, w]) => w > 0);
-  const depthTotal = activeDepths.reduce((s, [, w]) => s + w, 0);
-  const depthParam  = activeDepths.map(([d]) => d).join(',');
-  const weightParam = activeDepths.map(([, w]) => (w / depthTotal).toFixed(4)).join(',');
+  const depthTotal   = activeDepths.reduce((s, [, w]) => s + w, 0);
+  const depthParam   = activeDepths.map(([d]) => d).join(',');
+  const depthWeightParam = activeDepths.map(([, w]) => (w / depthTotal).toFixed(4)).join(',');
+
+  // Derive time params for API
+  const activeTimes  = Object.entries(timeWeights).filter(([, w]) => w > 0);
+  const timeTotal    = activeTimes.reduce((s, [, w]) => s + w, 0);
+  const timeParam    = activeTimes.map(([t]) => t).join(',');
+  const timeWeightParam = activeTimes.map(([, w]) => (w / timeTotal).toFixed(4)).join(',');
 
   //fetch geojson features for display
   useEffect(() => {
@@ -128,12 +134,12 @@ function App() {
 
   // Downstream fetch
   useEffect(() => {
-    if (direction !== 'downstream' || !clickIds?.length || !depthParam) {
+    if (direction !== 'downstream' || !clickIds?.length || !depthParam || !timeParam) {
       setConnections([]);
       return;
     }
     const ctrl = new AbortController();
-    const fetchURL = `api/connectivity?depth=${depthParam}&depth_weight=${weightParam}&time_range=${selectedTimes.join(',')}&start_id=${clickIds.join(',')}`;
+    const fetchURL = `api/connectivity?depth=${depthParam}&depth_weight=${depthWeightParam}&time_range=${timeParam}&time_weight=${timeWeightParam}&start_id=${clickIds.join(',')}`;
     console.log('Trying to fetch:', fetchURL);
     (async () => {
       try {
@@ -146,16 +152,16 @@ function App() {
       }
     })();
     return () => ctrl.abort();
-  }, [clickIds, selectedTimes, depthParam, weightParam, direction]);
+  }, [clickIds, timeParam, timeWeightParam, depthParam, depthWeightParam, direction]);
 
   // Upstream fetch
   useEffect(() => {
-    if (direction !== 'upstream' || !clickIds?.length || !depthParam) {
+    if (direction !== 'upstream' || !clickIds?.length || !depthParam || !timeParam) {
       setSourceConnections([]);
       return;
     }
     const ctrl = new AbortController();
-    const fetchURL = `api/connectivity-sources?depth=${depthParam}&depth_weight=${weightParam}&time_range=${selectedTimes.join(',')}&end_id=${clickIds.join(',')}&habitable=${isHabitableShown}`;
+    const fetchURL = `api/connectivity-sources?depth=${depthParam}&depth_weight=${depthWeightParam}&time_range=${timeParam}&time_weight=${timeWeightParam}&end_id=${clickIds.join(',')}&habitable=${isHabitableShown}`;
     console.log('Trying to fetch:', fetchURL);
     (async () => {
       try {
@@ -168,7 +174,7 @@ function App() {
       }
     })();
     return () => ctrl.abort();
-  }, [clickIds, selectedTimes, depthParam, weightParam, direction, isHabitableShown]);
+  }, [clickIds, timeParam, timeWeightParam, depthParam, depthWeightParam, direction, isHabitableShown]);
 
   const clearHex = () => {
     setClickIds([]);
@@ -514,8 +520,8 @@ function App() {
         <ControlPanel
           depthWeights={depthWeights}
           onDepthWeightsChange={setDepthWeights}
-          selectedTimes={selectedTimes}
-          onTimeChange={setSelectedTimes}
+          timeWeights={timeWeights}
+          onTimeWeightsChange={setTimeWeights}
           clearHex={clearHex}
           isAQCHighlighted={isAQCHighlighted}
           onAQCChange={setAQC}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import StaticMap from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import ControlPanel from './ControlPanel';
 import InfoBox from './InfoBox';
-import { theme } from './theme';
+import { theme, type RGBA } from './theme';
 
 // Free map styles (no API key required):
 // - https://tiles.openfreemap.org/styles/positron (minimal light gray)
@@ -183,6 +183,54 @@ function App() {
     return new Map<number, number>(sourceConnections.filter(c => c.raw_weight != null).map(c => [c.start_id, c.raw_weight!]));
   }, [direction, connections, sourceConnections]);
 
+  // Visual state for each hex — single source of truth for elevation and color.
+  // Separates rendering concerns from raw data (rawWeightMap is used only for tooltips).
+  //
+  //  connected        – in weightMap, shown with weight-based elevation + color
+  //  connected-dimmed – in weightMap but non-habitable in downstream+habitable mode
+  //                     shown flat with a de-saturated color (de-emphasised target)
+  //  excluded         – NOT in weightMap, non-habitable, upstream+habitable ON
+  //                     shown flat in light gray (excluded from the calculation)
+  //  dimmed           – NOT in weightMap, non-habitable, downstream+habitable ON
+  //                     shown flat in dark gray (deep/uninhabitable area)
+  type HexDisplayState =
+    | { kind: 'connected';        weight: number }
+    | { kind: 'connected-dimmed'; weight: number }
+    | { kind: 'excluded' }
+    | { kind: 'dimmed' };
+
+  const hexDisplayMap = useMemo(() => {
+    const map = new Map<number, HexDisplayState>();
+    if (!metadata) return map;
+
+    const isNonHabitable = (id: number) => {
+      const m = metadata[id];
+      return m != null && m.habitable == 0;
+    };
+
+    // Pass 1: all hexes in weightMap
+    for (const [id, w] of weightMap) {
+      if (isNonHabitable(id) && isHabitableShown && direction === 'downstream') {
+        map.set(id, { kind: 'connected-dimmed', weight: w });
+      } else {
+        map.set(id, { kind: 'connected', weight: w });
+      }
+    }
+
+    // Pass 2: non-habitable unconnected hexes when habitable filter is on
+    if (isHabitableShown) {
+      for (const idKey of Object.keys(metadata)) {
+        const id = Number(idKey);
+        if (map.has(id)) continue;
+        if (isNonHabitable(id)) {
+          map.set(id, direction === 'upstream' ? { kind: 'excluded' } : { kind: 'dimmed' });
+        }
+      }
+    }
+
+    return map;
+  }, [weightMap, metadata, isHabitableShown, direction]);
+
   // Helper: add z-coordinate to all positions in a geometry
   const addZToGeometry = (geometry: any, z: number): any => {
     const addZ = (coords: any): any => {
@@ -201,11 +249,11 @@ function App() {
     geometry: addZToGeometry(f.geometry, z),
   });
 
-  // Calculate connectivity height for a hex
+  // Calculate connectivity height for a hex (used to stack category layers)
   const getConnHeight = (id: number) => {
-    if (isHabitableShown && metadata && metadata[id]?.habitable == 0) return 0;
-    const w = weightMap.get(id);
-    return w !== undefined ? theme.elevation.getElevation(w) : 0;
+    const state = hexDisplayMap.get(id);
+    if (!state || state.kind !== 'connected') return 0;
+    return theme.elevation.getElevation(state.weight);
   };
 
   // Common layer properties
@@ -294,27 +342,34 @@ function App() {
           ...commonLayerProps,
           ...interactionHandlers,
           updateTriggers: {
-            getFillColor: [hoveredId, weightMap, clickIds, isHabitableShown],
-            getElevation: [weightMap, isHabitableShown],
+            getFillColor: [hexDisplayMap, hoveredId],
+            getElevation: [hexDisplayMap],
           },
           getElevation: (d: any) => {
-            const id = d.properties.id;
-            if (isHabitableShown && metadata && metadata[id]?.habitable == 0) return 0;
-            const w = weightMap.get(id);
-            if (w !== undefined) return theme.elevation.getElevation(w);
-            return theme.elevation.default;
+            const state = hexDisplayMap.get(d.properties.id);
+            if (!state || state.kind !== 'connected') return 0;
+            return theme.elevation.getElevation(state.weight);
           },
           getFillColor: (d: any) => {
             const id = d.properties.id;
-            const isDeep = isHabitableShown && metadata && metadata[id]?.habitable == 0;
             if (id === hoveredId) return theme.hex.hovered;
-            const w = weightMap.get(id);
-            if (w !== undefined) {
-              const c = theme.hex.getWeightColor(w);
-              return isDeep ? [Math.round(c[0]*0.45+70*0.55), Math.round(c[1]*0.45+70*0.55), Math.round(c[2]*0.45+70*0.55), c[3]] as [number,number,number,number] : c;
+            const state = hexDisplayMap.get(id);
+            if (!state) return theme.hex.default;
+            switch (state.kind) {
+              case 'connected':
+                return theme.hex.getWeightColor(state.weight);
+              case 'connected-dimmed': {
+                // connected but non-habitable target (downstream+habitable): flat, de-saturated
+                const c = theme.hex.getWeightColor(state.weight);
+                return [Math.round(c[0]*0.4+150*0.6), Math.round(c[1]*0.4+150*0.6), Math.round(c[2]*0.4+150*0.6), 180] as RGBA;
+              }
+              case 'excluded':
+                // upstream+habitable: non-habitable source excluded from calc, shown flat in light gray
+                return [180, 180, 180, 220] as RGBA;
+              case 'dimmed':
+                // downstream+habitable: non-habitable area, shown flat in dark gray
+                return [90, 90, 90, 200] as RGBA;
             }
-            if (isDeep) return theme.highlight.deepWater;
-            return theme.hex.default;
           },
         }),
 
@@ -329,7 +384,7 @@ function App() {
           },
           ...commonLayerProps,
           ...interactionHandlers,
-          updateTriggers: { data: [weightMap], getFillColor: [hoveredId] },
+          updateTriggers: { data: [hexDisplayMap], getFillColor: [hoveredId] },
           getElevation: catHeight,
           getFillColor: (d: any) => d.properties.id === hoveredId ? theme.hex.hovered : theme.highlight.historic,
         })] : []),
@@ -349,7 +404,7 @@ function App() {
           },
           ...commonLayerProps,
           ...interactionHandlers,
-          updateTriggers: { data: [weightMap, isHistoricHighlighted], getFillColor: [hoveredId] },
+          updateTriggers: { data: [hexDisplayMap, isHistoricHighlighted], getFillColor: [hoveredId] },
           getElevation: catHeight,
           getFillColor: (d: any) => d.properties.id === hoveredId ? theme.hex.hovered : theme.highlight.restoration,
         })] : []),
@@ -372,7 +427,7 @@ function App() {
           },
           ...commonLayerProps,
           ...interactionHandlers,
-          updateTriggers: { data: [weightMap, isHistoricHighlighted, isRestHighlighted], getFillColor: [hoveredId] },
+          updateTriggers: { data: [hexDisplayMap, isHistoricHighlighted, isRestHighlighted], getFillColor: [hoveredId] },
           getElevation: catHeight,
           getFillColor: (d: any) => d.properties.id === hoveredId ? theme.hex.hovered : theme.highlight.aquaculture,
         })] : []),
@@ -396,7 +451,7 @@ function App() {
           },
           ...commonLayerProps,
           ...interactionHandlers,
-          updateTriggers: { data: [weightMap, isHistoricHighlighted, isRestHighlighted, isAQCHighlighted], getFillColor: [hoveredId] },
+          updateTriggers: { data: [hexDisplayMap, isHistoricHighlighted, isRestHighlighted, isAQCHighlighted], getFillColor: [hoveredId] },
           getElevation: catHeight,
           getFillColor: (d: any) => d.properties.id === hoveredId ? theme.hex.hovered : theme.highlight.disease,
         })] : []),
@@ -421,7 +476,7 @@ function App() {
           },
           ...commonLayerProps,
           ...interactionHandlers,
-          updateTriggers: { data: [weightMap, clickIds, isHistoricHighlighted, isRestHighlighted, isAQCHighlighted, isDiseaseHighlighted], getFillColor: [hoveredId] },
+          updateTriggers: { data: [hexDisplayMap, clickIds, isHistoricHighlighted, isRestHighlighted, isAQCHighlighted, isDiseaseHighlighted], getFillColor: [hoveredId] },
           getElevation: catHeight,
           getFillColor: (d: any) => d.properties.id === hoveredId ? theme.hex.hovered : theme.highlight.selected,
         })] : []),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,8 +15,16 @@ import { theme } from './theme';
 // - https://demotiles.maplibre.org/style.json (original colorful demo)
 const MAP_STYLE = 'https://tiles.openfreemap.org/styles/positron';
 
+export type ConnDirection = 'downstream' | 'upstream';
+
 type Connection = {
   end_id: number;
+  weight: number;
+  raw_weight?: number;
+};
+
+type SourceConnection = {
+  start_id: number;
   weight: number;
   raw_weight?: number;
 };
@@ -64,6 +72,7 @@ function App() {
   const [isHabitableShown, setHabitable] = useState<boolean>(true);
   const [isHistoricHighlighted, setHistoric] = useState<boolean>(true);
   
+  const [direction, setDirection] = useState<ConnDirection>('downstream');
   const [hoveredId, setHoveredId] = useState<number | null>(null);
   const [clickIds, setClickIds] = useState<number[]>([]);
   const [tooltip, setTooltip] = useState<{x: number; y: number; content: string} | null>(null);
@@ -109,45 +118,70 @@ function App() {
   };
 
   const [connections, setConnections] = useState<Connection[]>([]);
+  const [sourceConnections, setSourceConnections] = useState<SourceConnection[]>([]);
 
-  // Fetch connectivity whenever (clickId, selectedTime, selectedDepth) change
+  // Downstream fetch
   useEffect(() => {
-    if (clickIds?.length) {
-
-      // TODO: Add request timeout (10s) for better UX
-      const ctrl = new AbortController();
-      const fetchURL = `api/connectivity?depth=${selectedDepths.join(',')}&time_range=${selectedTimes.join(',')}&start_id=${clickIds.join(',')}&op=mean`;
-      console.log("Trying to fetch: ", fetchURL);
-    
-      (async () => {
-        try {
-          const res = await fetch(fetchURL, { signal: ctrl.signal });
-          if (!res.ok) throw new Error(res.statusText);
-          const data: Connection[] = await res.json();
-          setConnections(data);
-        } catch (e: any) {
-          if (e.name !== 'AbortError') console.error('Fetch error:', e);
-        }
-      })();
-    return () => ctrl.abort();
+    if (direction !== 'downstream' || !clickIds?.length) {
+      setConnections([]);
+      return;
     }
-    setConnections([]);
-  }, [clickIds, selectedTimes, selectedDepths]);
+    const ctrl = new AbortController();
+    const fetchURL = `api/connectivity?depth=${selectedDepths.join(',')}&time_range=${selectedTimes.join(',')}&start_id=${clickIds.join(',')}&op=mean`;
+    console.log('Trying to fetch:', fetchURL);
+    (async () => {
+      try {
+        const res = await fetch(fetchURL, { signal: ctrl.signal });
+        if (!res.ok) throw new Error(res.statusText);
+        const data: Connection[] = await res.json();
+        setConnections(data);
+      } catch (e: any) {
+        if (e.name !== 'AbortError') console.error('Fetch error:', e);
+      }
+    })();
+    return () => ctrl.abort();
+  }, [clickIds, selectedTimes, selectedDepths, direction]);
+
+  // Upstream fetch
+  useEffect(() => {
+    if (direction !== 'upstream' || !clickIds?.length) {
+      setSourceConnections([]);
+      return;
+    }
+    const ctrl = new AbortController();
+    const fetchURL = `api/connectivity-sources?depth=${selectedDepths.join(',')}&time_range=${selectedTimes.join(',')}&end_id=${clickIds.join(',')}&habitable=${isHabitableShown}`;
+    console.log('Trying to fetch:', fetchURL);
+    (async () => {
+      try {
+        const res = await fetch(fetchURL, { signal: ctrl.signal });
+        if (!res.ok) throw new Error(res.statusText);
+        const data: SourceConnection[] = await res.json();
+        setSourceConnections(data);
+      } catch (e: any) {
+        if (e.name !== 'AbortError') console.error('Fetch error:', e);
+      }
+    })();
+    return () => ctrl.abort();
+  }, [clickIds, selectedTimes, selectedDepths, direction, isHabitableShown]);
 
   const clearHex = () => {
     setClickIds([]);
     setConnections([]);
+    setSourceConnections([]);
   }
 
-  // Derive weights from the latest connections; new Map reference whenever connections changes
-  const weightMap = useMemo(
-    () => new Map<number, number>(connections.map(c => [c.end_id, c.weight])),
-    [connections]
-  );
-  const rawWeightMap = useMemo(
-    () => new Map<number, number>(connections.filter(c => c.raw_weight != null).map(c => [c.end_id, c.raw_weight!])),
-    [connections]
-  );
+  // Derive weights from the active direction's connections
+  const weightMap = useMemo(() => {
+    if (direction === 'downstream')
+      return new Map<number, number>(connections.map(c => [c.end_id, c.weight]));
+    return new Map<number, number>(sourceConnections.map(c => [c.start_id, c.weight]));
+  }, [direction, connections, sourceConnections]);
+
+  const rawWeightMap = useMemo(() => {
+    if (direction === 'downstream')
+      return new Map<number, number>(connections.filter(c => c.raw_weight != null).map(c => [c.end_id, c.raw_weight!]));
+    return new Map<number, number>(sourceConnections.filter(c => c.raw_weight != null).map(c => [c.start_id, c.raw_weight!]));
+  }, [direction, connections, sourceConnections]);
 
   // Helper: add z-coordinate to all positions in a geometry
   const addZToGeometry = (geometry: any, z: number): any => {
@@ -198,7 +232,10 @@ function App() {
       if (!data) return;
       const rawWeight = rawWeightMap.get(info.object.properties.id);
       const concLine = (() => {
-        if (rawWeight == null || rawWeight <= 0) return 'rel conc 0';
+        if (rawWeight == null || rawWeight <= 0) return direction === 'upstream' ? 'source contrib 0%' : 'rel conc 0';
+        if (direction === 'upstream') {
+          return `source contrib ${(rawWeight * 100).toFixed(2)}%`;
+        }
         const exp = Math.floor(Math.log10(rawWeight));
         const mantissa = rawWeight / Math.pow(10, exp);
         return `rel conc ${mantissa.toFixed(2)} \u00b7 10<sup>${exp}</sup>`;
@@ -429,6 +466,8 @@ function App() {
           onHabitableChange={setHabitable}
           isHistoricHighlighted={isHistoricHighlighted}
           onHistoricChange={setHistoric}
+          direction={direction}
+          onDirectionChange={setDirection}
         />
       </div>
 

--- a/frontend/src/ControlPanel.tsx
+++ b/frontend/src/ControlPanel.tsx
@@ -2,9 +2,12 @@ import * as React from "react";
 import { theme } from "./theme";
 import type { ConnDirection } from "./App";
 
+// depthWeights: relative weight per depth key (0 = excluded)
+export type DepthWeights = Record<string, number>;
+
 interface ControlPanelProps {
-  selectedDepths: string[];
-  onDepthChange: (newDepths: string[]) => void;
+  depthWeights: DepthWeights;
+  onDepthWeightsChange: (w: DepthWeights) => void;
   selectedTimes: string[];
   onTimeChange: (newTimes: string[]) => void;
   clearHex?: (payload: { depths: string[]; times: string[] }) => void;
@@ -33,13 +36,12 @@ const times = [
   { value: "14d-28d", label: "14–28 days" },
 ];
 
-// helper to toggle values in an array
 const toggle = (list: string[], value: string) =>
   list.includes(value) ? list.filter(v => v !== value) : [...list, value];
 
 export default function ControlPanel({
-  selectedDepths,
-  onDepthChange,
+  depthWeights,
+  onDepthWeightsChange,
   selectedTimes,
   onTimeChange,
   clearHex,
@@ -58,8 +60,12 @@ export default function ControlPanel({
 }: ControlPanelProps) {
   const [collapsed, setCollapsed] = React.useState(() => window.innerWidth <= 480);
 
-  const handleDepthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onDepthChange(toggle(selectedDepths, e.target.value));
+  const depthTotal = Object.values(depthWeights).reduce((s, v) => s + v, 0);
+  const depthPct = (value: string) =>
+    depthTotal > 0 ? Math.round((depthWeights[value] ?? 0) / depthTotal * 100) : 0;
+
+  const handleDepthSlider = (value: string, raw: number) => {
+    onDepthWeightsChange({ ...depthWeights, [value]: raw });
   };
 
   const handleTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -118,7 +124,7 @@ export default function ControlPanel({
         </button>
         <button
           type="button"
-          onClick={() => clearHex?.({ depths: selectedDepths, times: selectedTimes })}
+          onClick={() => clearHex?.({ depths: Object.keys(depthWeights).filter(d => depthWeights[d] > 0), times: selectedTimes })}
           style={{
             background: "transparent",
             border: "none",
@@ -135,18 +141,23 @@ export default function ControlPanel({
 
       <div className="control-panel-section">
         <div className="control-panel-section-label">Drifting Depth</div>
-        <div className="control-panel-section-options">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
           {depths.map(({ value, label }) => (
-            <label key={value} className="control-panel-option">
+            <div key={value} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={{ width: 54, flexShrink: 0 }}>{label.replace(' meters', ' m')}</span>
               <input
-                type="checkbox"
-                name="depth"
-                value={value}
-                checked={selectedDepths.includes(value)}
-                onChange={handleDepthChange}
+                type="range"
+                min={0}
+                max={10}
+                step={1}
+                value={depthWeights[value] ?? 0}
+                onChange={e => handleDepthSlider(value, Number(e.target.value))}
+                style={{ flex: 1, minWidth: 0 }}
               />
-              {label}
-            </label>
+              <span style={{ width: 32, textAlign: 'right', opacity: depthWeights[value] ? 1 : 0.35 }}>
+                {depthPct(value)}%
+              </span>
+            </div>
           ))}
         </div>
       </div>

--- a/frontend/src/ControlPanel.tsx
+++ b/frontend/src/ControlPanel.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { theme } from "./theme";
+import type { ConnDirection } from "./App";
 
 interface ControlPanelProps {
   selectedDepths: string[];
@@ -17,6 +18,8 @@ interface ControlPanelProps {
   onHabitableChange: (v: boolean) => void;
   isHistoricHighlighted: boolean;
   onHistoricChange: (v: boolean) => void;
+  direction: ConnDirection;
+  onDirectionChange: (d: ConnDirection) => void;
 }
 
 const depths = [
@@ -50,6 +53,8 @@ export default function ControlPanel({
   onHabitableChange,
   isHistoricHighlighted,
   onHistoricChange,
+  direction,
+  onDirectionChange,
 }: ControlPanelProps) {
   const [collapsed, setCollapsed] = React.useState(() => window.innerWidth <= 480);
 
@@ -215,6 +220,38 @@ export default function ControlPanel({
 
     </fieldset>
 
+      {/* Upstream toggle */}
+      <div className="control-panel-section" style={{ marginTop: 4 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            id="upstream-toggle"
+            type="checkbox"
+            checked={direction === 'upstream'}
+            onChange={(e) => onDirectionChange(e.target.checked ? 'upstream' : 'downstream')}
+            style={{ position: 'absolute', opacity: 0, width: 0, height: 0 }}
+          />
+          <label htmlFor="upstream-toggle" style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+            <div style={{ position: 'relative', flexShrink: 0, width: 34, height: 18 }}>
+              <div style={{
+                position: 'absolute', inset: 0,
+                backgroundColor: direction === 'upstream' ? '#4a9eff' : '#555',
+                borderRadius: 9, transition: 'background-color .2s',
+              }}>
+                <div style={{
+                  position: 'absolute', top: 2, width: 14, height: 14,
+                  left: direction === 'upstream' ? 18 : 2,
+                  backgroundColor: 'white', borderRadius: '50%', transition: 'left .2s',
+                }} />
+              </div>
+            </div>
+            <div style={{ lineHeight: 1.3 }}>
+              <div style={{ whiteSpace: 'nowrap' }}>upstream</div>
+              <div style={{ opacity: 0.65, whiteSpace: 'nowrap' }}>{direction === 'upstream' ? 'click target · see sources' : 'click source · see targets'}</div>
+            </div>
+          </label>
+        </div>
+      </div>
+
       {/* Habitable toggle — separate from highlights */}
       <div className="control-panel-section" style={{ marginTop: 4 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -259,7 +296,7 @@ export default function ControlPanel({
           <span style={{ opacity: 0.7 }}>high</span>
         </div>
         <div style={{ marginTop: 3, opacity: 0.75, fontWeight: 'normal' }}>
-          Relative concentration (logarithmic scale)
+          {direction === 'upstream' ? 'Source contribution (logarithmic scale)' : 'Relative concentration (logarithmic scale)'}
         </div>
       </div>
     </div>

--- a/frontend/src/ControlPanel.tsx
+++ b/frontend/src/ControlPanel.tsx
@@ -2,14 +2,15 @@ import * as React from "react";
 import { theme } from "./theme";
 import type { ConnDirection } from "./App";
 
-// depthWeights: relative weight per depth key (0 = excluded)
+// relative weight per key (0 = excluded)
 export type DepthWeights = Record<string, number>;
+export type TimeWeights  = Record<string, number>;
 
 interface ControlPanelProps {
   depthWeights: DepthWeights;
   onDepthWeightsChange: (w: DepthWeights) => void;
-  selectedTimes: string[];
-  onTimeChange: (newTimes: string[]) => void;
+  timeWeights: TimeWeights;
+  onTimeWeightsChange: (w: TimeWeights) => void;
   clearHex?: (payload: { depths: string[]; times: string[] }) => void;
   isAQCHighlighted: boolean;
   onAQCChange: (newAQC: boolean) => void;
@@ -36,14 +37,11 @@ const times = [
   { value: "14d-28d", label: "14–28 days" },
 ];
 
-const toggle = (list: string[], value: string) =>
-  list.includes(value) ? list.filter(v => v !== value) : [...list, value];
-
 export default function ControlPanel({
   depthWeights,
   onDepthWeightsChange,
-  selectedTimes,
-  onTimeChange,
+  timeWeights,
+  onTimeWeightsChange,
   clearHex,
   isAQCHighlighted,
   onAQCChange,
@@ -68,8 +66,12 @@ export default function ControlPanel({
     onDepthWeightsChange({ ...depthWeights, [value]: raw });
   };
 
-  const handleTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onTimeChange(toggle(selectedTimes, e.target.value));
+  const timeTotal = Object.values(timeWeights).reduce((s, v) => s + v, 0);
+  const timePct = (value: string) =>
+    timeTotal > 0 ? Math.round((timeWeights[value] ?? 0) / timeTotal * 100) : 0;
+
+  const handleTimeSlider = (value: string, raw: number) => {
+    onTimeWeightsChange({ ...timeWeights, [value]: raw });
   };
 
   const stopScroll = (e: React.WheelEvent | React.TouchEvent) => {
@@ -124,7 +126,7 @@ export default function ControlPanel({
         </button>
         <button
           type="button"
-          onClick={() => clearHex?.({ depths: Object.keys(depthWeights).filter(d => depthWeights[d] > 0), times: selectedTimes })}
+          onClick={() => clearHex?.({ depths: Object.keys(depthWeights).filter(d => depthWeights[d] > 0), times: Object.keys(timeWeights).filter(t => timeWeights[t] > 0) })}
           style={{
             background: "transparent",
             border: "none",
@@ -164,18 +166,23 @@ export default function ControlPanel({
 
       <div className="control-panel-section">
         <div className="control-panel-section-label">Time range</div>
-        <div className="control-panel-section-options">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
           {times.map(({ value, label }) => (
-            <label key={value} className="control-panel-option">
+            <div key={value} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={{ width: 54, flexShrink: 0 }}>{label}</span>
               <input
-                type="checkbox"
-                name="time"
-                value={value}
-                checked={selectedTimes.includes(value)}
-                onChange={handleTimeChange}
+                type="range"
+                min={0}
+                max={10}
+                step={1}
+                value={timeWeights[value] ?? 0}
+                onChange={e => handleTimeSlider(value, Number(e.target.value))}
+                style={{ flex: 1, minWidth: 0 }}
               />
-              {label}
-            </label>
+              <span style={{ width: 32, textAlign: 'right', opacity: timeWeights[value] ? 1 : 0.35 }}>
+                {timePct(value)}%
+              </span>
+            </div>
           ))}
         </div>
       </div>

--- a/frontend/src/ControlPanel.tsx
+++ b/frontend/src/ControlPanel.tsx
@@ -220,35 +220,30 @@ export default function ControlPanel({
 
     </fieldset>
 
-      {/* Upstream toggle */}
+      {/* Direction radio buttons */}
       <div className="control-panel-section" style={{ marginTop: 4 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <input
-            id="upstream-toggle"
-            type="checkbox"
-            checked={direction === 'upstream'}
-            onChange={(e) => onDirectionChange(e.target.checked ? 'upstream' : 'downstream')}
-            style={{ position: 'absolute', opacity: 0, width: 0, height: 0 }}
-          />
-          <label htmlFor="upstream-toggle" style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
-            <div style={{ position: 'relative', flexShrink: 0, width: 34, height: 18 }}>
-              <div style={{
-                position: 'absolute', inset: 0,
-                backgroundColor: direction === 'upstream' ? '#4a9eff' : '#555',
-                borderRadius: 9, transition: 'background-color .2s',
-              }}>
-                <div style={{
-                  position: 'absolute', top: 2, width: 14, height: 14,
-                  left: direction === 'upstream' ? 18 : 2,
-                  backgroundColor: 'white', borderRadius: '50%', transition: 'left .2s',
-                }} />
-              </div>
-            </div>
-            <div style={{ lineHeight: 1.3 }}>
-              <div style={{ whiteSpace: 'nowrap' }}>upstream</div>
-              <div style={{ opacity: 0.65, whiteSpace: 'nowrap' }}>{direction === 'upstream' ? 'click target · see sources' : 'click source · see targets'}</div>
-            </div>
-          </label>
+        <div className="control-panel-section-label">Direction</div>
+        <div className="control-panel-section-options">
+          {([
+            { value: 'downstream', label: 'Downstream', sub: 'select source · see targets' },
+            { value: 'upstream',   label: 'Upstream',   sub: 'select target · see sources' },
+          ] as const).map(({ value, label, sub }) => (
+            <label key={value} className="control-panel-option" style={{ alignItems: 'flex-start' }}>
+              <input
+                type="radio"
+                name="direction"
+                value={value}
+                checked={direction === value}
+                onChange={() => onDirectionChange(value)}
+                style={{ marginTop: 2 }}
+              />
+              <span style={{ lineHeight: 1.3 }}>
+                <span>{label}</span>
+                <br />
+                <span style={{ opacity: 0.65 }}>{sub}</span>
+              </span>
+            </label>
+          ))}
         </div>
       </div>
 

--- a/plans/reverse-conn-00-plan.md
+++ b/plans/reverse-conn-00-plan.md
@@ -1,0 +1,197 @@
+# Reverse Connectivity — Plan
+
+Branch: `explore/reverse-connectivity`
+
+## Goal
+
+Add an **incoming toggle** to the UI: instead of showing where water from a
+source hex disperses to (forward/outgoing), show which source hexes contribute
+to the water at a target hex (reverse/incoming).
+
+**Physical interpretation of incoming view:**
+Put the same dye concentration into every connected, habitable source hex
+simultaneously. Measure concentration at the target. Show each source's
+percentage of the total.
+
+---
+
+## Science
+
+Forward weight stored in DB:
+```
+F(s→t) = [obs_sum / (N_s × DT_h × n_months_years)] × (wf_s / wf_t)
+```
+This is concentration at t per unit concentration at s.
+
+Fractional contribution of source s to target t:
+```
+share(s→t) = F(s→t) / Σ_s F(s→t)
+```
+
+`wf_t` cancels in the ratio, so the stored F values are sufficient — no schema
+change needed.
+
+**Habitable filter semantics (critical):**
+When the habitable toggle is ON, non-habitable hexes are excluded from the
+denominator entirely — not just hidden visually. They cannot host populations
+and are not meaningful sources. The sum is over habitable sources only:
+```
+share(s→t) = F(s→t) / Σ_{s ∈ habitable} F(s→t)   [habitable ON]
+share(s→t) = F(s→t) / Σ_s F(s→t)                  [habitable OFF]
+```
+
+---
+
+## Changes
+
+### 1. DB — add reverse query index
+
+`database/init/init_db.py` (or a migration script)
+
+```sql
+CREATE INDEX idx_connect_dtr_inc_reverse
+ON connectivity_table (depth, time_range, end_id)
+INCLUDE (start_id, weight);
+```
+
+Existing index covers forward queries; this covers reverse.
+
+### 2. API — new endpoint `/connectivity-sources`
+
+`api/server.js`
+
+```
+GET /connectivity-sources?end_id=42,100&depth=05m,10m&time_range=07d-14d&habitable=true
+```
+
+- Filter by `end_id` (not `start_id`)
+- When `habitable=true`: join `metadata_table` and restrict source rows to
+  `m.habitable = 1`
+- Aggregate by `start_id` using same time-weighted mean as `/connectivity`
+- Compute fractional shares server-side: `weight / SUM(weight)` after
+  aggregation
+- Return `[{ start_id, weight (fractional share 0–1), raw_weight (absolute F) }]`
+- Apply log-normalisation to `weight` for visual encoding (same as forward)
+- No `404` when result is empty — just return `[]`
+
+Validation: mirror `/connectivity` (same depth/time_range rules; `end_id`
+instead of `start_id`, same integer validation, max 10 000 items).
+
+### 3. Frontend types
+
+`frontend/src/App.tsx`
+
+```ts
+type ConnDirection = 'downstream' | 'upstream';
+
+type SourceConnection = {
+  start_id: number;
+  weight: number;       // log-normalised, for visual encoding
+  raw_weight?: number;  // fractional share 0–1, for tooltip
+};
+```
+
+### 4. Frontend state & fetch
+
+`frontend/src/App.tsx`
+
+Add:
+```ts
+const [direction, setDirection] = useState<ConnDirection>('forward');
+const [sourceConnections, setSourceConnections] = useState<SourceConnection[]>([]);
+```
+
+Second fetch effect, triggered by `[clickIds, selectedTimes, selectedDepths,
+direction, isHabitableShown]`:
+- If `direction === 'downstream'`: existing fetch (unchanged)
+- If `direction === 'upstream'`: fetch
+  `/connectivity-sources?end_id=...&depth=...&time_range=...&habitable=<bool>`
+
+When direction changes: clear both `connections` and `sourceConnections`.
+
+`weightMap` derived from active direction:
+```ts
+const weightMap = useMemo(() => {
+  if (direction === 'downstream')
+    return new Map(connections.map(c => [c.end_id, c.weight]));
+  return new Map(sourceConnections.map(c => [c.start_id, c.weight]));
+}, [direction, connections, sourceConnections]);
+
+const rawWeightMap = useMemo(() => {
+  if (direction === 'downstream')
+    return new Map(connections.filter(c => c.raw_weight != null).map(c => [c.end_id, c.raw_weight!]));
+  return new Map(sourceConnections.filter(c => c.raw_weight != null).map(c => [c.start_id, c.raw_weight!]));
+}, [direction, connections, sourceConnections]);
+```
+
+The selected hex (orange) is always the clicked hex — it's the source in
+forward mode and the target in reverse mode. No change to click/selection logic.
+
+### 5. Tooltip — reverse mode label
+
+`frontend/src/App.tsx` (tooltip construction)
+
+- Forward: `rel conc X.XX · 10^N` (unchanged)
+- Reverse: `source contrib X.X%` (raw_weight × 100, formatted to 1 decimal)
+
+### 6. Scale bar label
+
+`frontend/src/ControlPanel.tsx`
+
+Pass `direction` prop; show context-sensitive label:
+- Forward: `Relative concentration (logarithmic scale)` (unchanged)
+- Reverse: `Source contribution (logarithmic scale)`
+
+### 7. ControlPanel — direction toggle
+
+`frontend/src/ControlPanel.tsx`
+
+Add a slide toggle (same style as habitable toggle) placed **above** the
+habitable toggle:
+
+```
+[ toggle ] upstream
+           click target(s) · see their sources
+```
+
+When OFF (default): downstream mode — existing behaviour.
+When ON: upstream mode.
+
+`ConnDirection` values renamed accordingly: `'downstream' | 'upstream'`.
+
+Props added:
+```ts
+direction: ConnDirection;
+onDirectionChange: (d: ConnDirection) => void;
+```
+
+---
+
+## What does NOT change
+
+- DB schema (no new tables; one new index)
+- Forward connectivity logic — untouched
+- Category highlight layers, layer stacking, habitable dimming display
+- Click/selection logic — selected hex always shown orange
+- Depth/time-range checkboxes — same semantics in both directions
+
+---
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `database/init/init_db.py` | Add reverse index |
+| `api/server.js` | Add `/connectivity-sources` endpoint |
+| `frontend/src/App.tsx` | `direction` state, second fetch, unified weightMap, tooltip label |
+| `frontend/src/ControlPanel.tsx` | Direction toggle, scale bar label, new props |
+
+---
+
+## YOUR QUESTIONS/NOTES
+
+- Direction toggle placement: above habitable toggle — OK?
+- Toggle labels: downstream (off) / upstream (on) — confirmed.
+- Multi-target upstream: aggregate by source across all selected targets
+  (time-weighted mean per source), then compute fractional shares over the
+  pooled result — confirmed, same as downstream multi-select.


### PR DESCRIPTION
## Summary

- **Upstream mode**: select a target hex, see fractional % contribution of each source hex. Direction toggle (radio buttons) in control panel: Downstream / Upstream with subtitles "select source · see targets" / "select target · see sources"
- **Habitable filter in upstream mode**: excludes non-habitable sources from the denominator so percentages sum to 100% within habitable sources only
- **Depth weighting**: checkboxes replaced by sliders (0 = excluded) with live normalised % readout. User can set e.g. 5 m = 25%, 10 m = 50%, 15 m = 25%
- **Time-range weighting**: same slider+% pattern for time windows
- Both weight dimensions multiplied together in the API weighted mean (depth_weight × time_weight per row)
- New `/connectivity-sources` API endpoint; `parseDepthWeights()` helper reused for both axes
- DB: reverse index `idx_connect_dtr_inc_reverse` for upstream query performance
- Redesigned visual state logic (`hexDisplayMap`) that cleanly separates tooltip data from elevation/color rendering

## Known issues

- Non-habitable hex dimming in upstream+habitable mode is still not visually working as intended

## Test plan

- [ ] Upstream mode: click a hex, verify source contributions appear with weight-based colours
- [ ] Toggle habitable filter, verify tooltip percentages change
- [ ] Adjust depth sliders to unequal weights, verify results shift accordingly
- [ ] Set a depth or time slider to 0, verify that window is excluded from the fetch
- [ ] Downstream mode still works as before
- [ ] Investigate and fix non-habitable hex visibility in upstream+habitable mode